### PR TITLE
Make remote client IP available on the RouteRequest

### DIFF
--- a/Source/RouteRequest.h
+++ b/Source/RouteRequest.h
@@ -1,12 +1,14 @@
 #import <Foundation/Foundation.h>
 @class HTTPMessage;
+@class RoutingConnection;
 
 @interface RouteRequest : NSObject
 
 @property (nonatomic, readonly) NSDictionary *headers;
 @property (nonatomic, readonly) NSDictionary *params;
+@property (nonatomic, readonly) RoutingConnection *connection;
 
-- (id)initWithHTTPMessage:(HTTPMessage *)msg parameters:(NSDictionary *)params;
+- (id)initWithHTTPMessage:(HTTPMessage *)msg parameters:(NSDictionary *)params connection:(RoutingConnection *)connection;
 - (NSString *)header:(NSString *)field;
 - (id)param:(NSString *)name;
 - (NSString *)method;

--- a/Source/RouteRequest.m
+++ b/Source/RouteRequest.m
@@ -1,16 +1,19 @@
 #import "RouteRequest.h"
 #import "HTTPMessage.h"
+#import "RoutingConnection.h"
 
 @implementation RouteRequest {
 	HTTPMessage *message;
 }
 
 @synthesize params;
+@synthesize connection;
 
-- (id)initWithHTTPMessage:(HTTPMessage *)msg parameters:(NSDictionary *)parameters {
+- (id)initWithHTTPMessage:(HTTPMessage *)msg parameters:(NSDictionary *)parameters connection:(RoutingConnection *)conn {
 	if (self = [super init]) {
 		params = parameters;
 		message = msg;
+        connection = conn;
 	}
 	return self;
 }

--- a/Source/RoutingConnection.h
+++ b/Source/RoutingConnection.h
@@ -3,4 +3,5 @@
 @class RoutingHTTPServer;
 
 @interface RoutingConnection : HTTPConnection
+@property (nonatomic, readonly) NSString *connectedHost;
 @end

--- a/Source/RoutingConnection.m
+++ b/Source/RoutingConnection.m
@@ -2,6 +2,8 @@
 #import "RoutingHTTPServer.h"
 #import "HTTPMessage.h"
 #import "HTTPResponseProxy.h"
+#import "GCDAsyncSocket.h"
+
 
 @implementation RoutingConnection {
 	__unsafe_unretained RoutingHTTPServer *http;
@@ -132,6 +134,10 @@
 	}
 
 	return shouldDie;
+}
+
+- (NSString *) connectedHost {
+    return [asyncSocket connectedHost];
 }
 
 @end

--- a/Source/RoutingHTTPServer.m
+++ b/Source/RoutingHTTPServer.m
@@ -244,7 +244,7 @@
 			params = newParams;
 		}
 
-		RouteRequest *request = [[RouteRequest alloc] initWithHTTPMessage:httpMessage parameters:params];
+        RouteRequest *request = [[RouteRequest alloc] initWithHTTPMessage:httpMessage parameters:params connection: (RoutingConnection *) connection];
 		RouteResponse *response = [[RouteResponse alloc] initWithConnection:connection];
 		if (!routeQueue) {
 			[self handleRoute:route withRequest:request response:response];


### PR DESCRIPTION
This allows for differentiated behaviour based on client remote ip.

Example:

```
[self.httpServer handleMethod:@"GET" withPath:@"/" block:^(RouteRequest *request, RouteResponse *response) {
    RoutingConnection *connection = request.connection;
    NSString *connectedHost = [connection connectedHost];

    [response setStatusCode:200];
    [response setHeader:@"Content-Type" value:@"text/html"];
    [response respondWithString:[NSString stringWithFormat:@"Hello World [%@]", connectedHost];
}];
```
