### PR TITLE
Change to __weak from __unsafe_unretained to fix crashes during unit …

### DIFF
--- a/RoutingHTTPServer.podspec
+++ b/RoutingHTTPServer.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Source'
 
   s.requires_arc = true
-  s.ios.deployment_target = '4.0'
+  s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
 
   s.dependency 'CocoaHTTPServer', '~> 2.3'

--- a/Source/RoutingConnection.m
+++ b/Source/RoutingConnection.m
@@ -4,7 +4,7 @@
 #import "HTTPResponseProxy.h"
 
 @implementation RoutingConnection {
-	__unsafe_unretained RoutingHTTPServer *http;
+	__weak RoutingHTTPServer *http;
 	NSDictionary *headers;
 }
 


### PR DESCRIPTION
…testing of many threaded HTTP responses in [WebApiClient](https://github.com/Blue-Rocket/WebApiClient) project unit tests. I kept getting crashes from the `setHeadersForResponse:error:` method, on the line that calls `[http.defaultHeaders enumerateKeysAndObjectsUsingBlock:...` and I noticed the `__unsafe_unretained` ivar. Switching to `__weak` resolved the crashes for me.
